### PR TITLE
Week6/juhwan

### DIFF
--- a/spring-fw-juhwan/src/main/java/com/fw/Main.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/Main.java
@@ -15,5 +15,9 @@ public class Main {
 
     HelloService helloService = context.getBean(HelloService.class);
     helloService.sayHello();
+
+    for (int i = 0; i < 10; i++) {
+      context.getBean("gamjaServiceImpl");
+    }
   }
 }

--- a/spring-fw-juhwan/src/main/java/com/fw/Main.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/Main.java
@@ -1,18 +1,19 @@
 package com.fw;
 
 import com.fw.week5.HelloService;
+import com.fw.week6.AppConfig;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 @Slf4j
 public class Main {
 
   public static void main(String[] args) {
-    ConfigurableApplicationContext context = new ClassPathXmlApplicationContext("week5.xml");
-    HelloService helloService = context.getBean(HelloService.class);
+    ApplicationContext context =
+        new AnnotationConfigApplicationContext(AppConfig.class);
 
+    HelloService helloService = context.getBean(HelloService.class);
     helloService.sayHello();
-    context.close();
   }
 }

--- a/spring-fw-juhwan/src/main/java/com/fw/week5/GamjaServiceImpl.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/week5/GamjaServiceImpl.java
@@ -1,15 +1,23 @@
 package com.fw.week5;
 
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
 @Slf4j
+@Scope("prototype")
 @Service("gamjaServiceImpl")
 public class GamjaServiceImpl implements MyService {
 
   @Value("${gamja.count}")
   private int count;
+
+  @PostConstruct
+  public void init() {
+    log.info("Gamja service init...");
+  }
 
   @Override
   public void hello() {

--- a/spring-fw-juhwan/src/main/java/com/fw/week5/GamjaServiceImpl.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/week5/GamjaServiceImpl.java
@@ -2,8 +2,10 @@ package com.fw.week5;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 @Slf4j
+@Service("gamjaServiceImpl")
 public class GamjaServiceImpl implements MyService {
 
   @Value("${gamja.count}")

--- a/spring-fw-juhwan/src/main/java/com/fw/week5/HelloService.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/week5/HelloService.java
@@ -3,7 +3,9 @@ package com.fw.week5;
 import jakarta.annotation.Resource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
 
+@Service
 public class HelloService {
 
   @Autowired

--- a/spring-fw-juhwan/src/main/java/com/fw/week5/MyServiceImpl.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/week5/MyServiceImpl.java
@@ -1,8 +1,10 @@
 package com.fw.week5;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @Slf4j
+@Service("myServiceImpl")
 public class MyServiceImpl implements MyService {
 
   @Override

--- a/spring-fw-juhwan/src/main/java/com/fw/week6/AppConfig.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/week6/AppConfig.java
@@ -1,0 +1,20 @@
+package com.fw.week6;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+@Slf4j
+@Configuration
+@ComponentScan("com.fw")
+@PropertySource("classpath:gamja.properties")
+public class AppConfig {
+
+  @Bean
+  public static PropertySourcesPlaceholderConfigurer propertyConfigurer() {
+    return new PropertySourcesPlaceholderConfigurer();
+  }
+}


### PR DESCRIPTION
### Issue: #61 

### Task

#### 1. 빈을 정의할 때, Stereotype Annotation을 사용하는 이유를 설명해봅시다.
- Stereotype Annotation은 애플리케이션의 계층 구조를 명확하게 표현합니다.
- 코드를 보는 것만으로 클래스의 책임과 위치를 이해하기 쉬워집니다.

#### 2. Stereotype Annotation 중 @Service 를 사용하여 빈 정의를 합니다.
<img width="1000"  alt="image" src="https://github.com/user-attachments/assets/ec2713ee-2c0b-4753-9b9e-e4ad2a6de014" />


#### 3. GamjaServiceImpl 빈을 사용할 때마다 새로운 빈을 만들어 사용하도록 Scope를 지정해봅시다.
<img width="1000"  alt="image" src="https://github.com/user-attachments/assets/e84eaa10-7980-4628-b483-c3c5d3ae8845" />
