### PR TITLE
Week6/Sangjin

### DIFF
--- a/spring-fw-sangjin/src/main/java/com/fw/week6/AppConfig.java
+++ b/spring-fw-sangjin/src/main/java/com/fw/week6/AppConfig.java
@@ -1,0 +1,19 @@
+package com.fw.week6;
+
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+/**
+ * Week 6 Java Config
+ *
+ * @Service Annotation을 사용하기 위한 사전 작업:
+ *   - @ComponentScan: 지정된 패키지 하위의 @Component, @Service, @Repository, @Controller
+ *                     어노테이션이 붙은 클래스들을 자동으로 빈으로 등록한다.
+ *   - @PropertySource: GamjaServiceImpl의 @Value("${gamja.count}")가 동작하도록 properties 로드.
+ */
+@Configuration
+@ComponentScan(basePackages = "com.fw.week6")
+@PropertySource("classpath:gamja.properties")
+public class AppConfig {
+}

--- a/spring-fw-sangjin/src/main/java/com/fw/week6/GamjaServiceImpl.java
+++ b/spring-fw-sangjin/src/main/java/com/fw/week6/GamjaServiceImpl.java
@@ -1,0 +1,26 @@
+package com.fw.week6;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Service;
+
+@Service("gamjaService")
+@Scope(value = "prototype", proxyMode = ScopedProxyMode.NO)
+public class GamjaServiceImpl implements MyService {
+
+    @Value("${gamja.count}")
+    private int count;
+
+    public GamjaServiceImpl() {
+        // 생성자가 호출될 때마다 새 인스턴스가 만들어진다는 증거 로그
+        System.out.println("  >> [GamjaServiceImpl] 새로운 인스턴스 생성! hashCode=" 
+                + Integer.toHexString(System.identityHashCode(this)));
+    }
+
+    @Override
+    public void hello() {
+        System.out.println("  [GamjaServiceImpl] 강원도 감자 " + count 
+                + "개 (인스턴스: " + Integer.toHexString(System.identityHashCode(this)) + ")");
+    }
+}

--- a/spring-fw-sangjin/src/main/java/com/fw/week6/MyService.java
+++ b/spring-fw-sangjin/src/main/java/com/fw/week6/MyService.java
@@ -1,0 +1,5 @@
+package com.fw.week6;
+
+public interface MyService {
+    void hello();
+}

--- a/spring-fw-sangjin/src/main/java/com/fw/week6/MyServiceImpl.java
+++ b/spring-fw-sangjin/src/main/java/com/fw/week6/MyServiceImpl.java
@@ -1,0 +1,12 @@
+package com.fw.week6;
+
+import org.springframework.stereotype.Service;
+
+@Service("myService")
+public class MyServiceImpl implements MyService {
+
+    @Override
+    public void hello() {
+        System.out.println("[MyServiceImpl] 안녕하세요! 저는 MyServiceImpl 입니다.");
+    }
+}

--- a/spring-fw-sangjin/src/main/java/com/fw/week6/Week6Main.java
+++ b/spring-fw-sangjin/src/main/java/com/fw/week6/Week6Main.java
@@ -1,0 +1,54 @@
+package com.fw.week6;
+
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+public class Week6Main {
+
+    public static void main(String[] args) {
+
+        System.out.println("Week6: Stereotype Annotation & Scope 실습");
+        System.out.println("==========================================\n");
+
+        // [STEP 1] AnnotationConfigApplicationContext 로드
+        System.out.println("[STEP 1] AnnotationConfigApplicationContext 로드");
+        System.out.println("  - 설정 클래스: AppConfig.class");
+        System.out.println("  - @ComponentScan(basePackages = \"com.fw.week6\")");
+        System.out.println("  - @PropertySource(\"classpath:gamja.properties\")\n");
+
+        try (AnnotationConfigApplicationContext ctx =
+                     new AnnotationConfigApplicationContext(AppConfig.class)) {
+
+            System.out.println("  => ApplicationContext 로드 완료!\n");
+
+            // [STEP 2] 등록된 빈 목록 확인
+            System.out.println("[STEP 2] 등록된 빈 목록 확인");
+            String[] beanNames = ctx.getBeanDefinitionNames();
+            for (int i = 0; i < beanNames.length; i++) {
+                String scope = ctx.getBeanDefinition(beanNames[i]).getScope();
+                if (scope.isEmpty()) scope = "singleton";
+                System.out.printf("  [%d] %s (scope: %s)%n", i + 1, beanNames[i], scope);
+            }
+            System.out.printf("  => 총 %d개의 빈 등록됨%n%n", beanNames.length);
+
+            // [STEP 3] @Service: MyServiceImpl 호출
+            System.out.println("[STEP 3] @Service: MyServiceImpl 빈 호출");
+            MyService myService = ctx.getBean("myService", MyService.class);
+            System.out.print("  => ");
+            myService.hello();
+            System.out.println();
+
+            // [STEP 4] @Scope("prototype"): GamjaServiceImpl 10번 호출
+            System.out.println("[STEP 4] @Scope(\"prototype\"): GamjaServiceImpl 10번 호출");
+            System.out.println("  - getBean() 호출마다 새로운 인스턴스가 생성됩니다.\n");
+
+            for (int i = 1; i <= 10; i++) {
+                System.out.printf("  [%2d회차] getBean(\"gamjaService\") 호출%n", i);
+                MyService gamjaService = ctx.getBean("gamjaService", MyService.class);
+                gamjaService.hello();
+                System.out.println();
+            }
+
+            System.out.println("=> 결과: prototype 스코프이므로 10개의 서로 다른 인스턴스가 생성되었습니다.");
+        }
+    }
+}


### PR DESCRIPTION
1.  <bean> 태그로 빈을 일일히 등록 시 클래스가 많아질수록 설정 파일이 커지고 관리가 어려워짐.
Stereotype annotaion을 사용하면 클래스 자체에 빈 정의를 선언할 수 있어 XML 설정 없이도 Component Scan을 통해 자동으로 빈이 등록되어 파악이 편함.

2.
<img width="1536" height="822" alt="image" src="https://github.com/user-attachments/assets/0f630303-d61c-4e65-ade8-308b34779768" />

3.
기존 스코프인 Singleton은 컨테이너에서 빈을 한개만 생성하여 공유하는데, 사용할 때마다 새로운 빈을 만들어 사용을 위해 getBean() 호출할 때마다 매번 새로운 인스턴스를 생성하는 prototype 스코프 사용
<img width="1540" height="842" alt="image" src="https://github.com/user-attachments/assets/82005b25-f544-4d5c-90ce-d686173c463f" />
<img width="1536" height="756" alt="image" src="https://github.com/user-attachments/assets/7c016cc6-3982-4cf5-8f29-178572a46caa" />
 