### PR TITLE
Week6/suhyeon

### DIFF
--- a/spring-fw-suheyon/src/main/java/com/fw/Main.java
+++ b/spring-fw-suheyon/src/main/java/com/fw/Main.java
@@ -11,13 +11,14 @@ public class Main {
 
   public static void main(String[] args) {
 
-    // xml
-    // ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("week5.xml");
-    // AppConfig
     AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(AppConfig.class);
 
     HelloService helloService = context.getBean(HelloService.class);
     helloService.sayHello();
+
+    for (int i = 0; i < 10; i++) {
+      context.getBean("gamjaServiceImpl");
+    }
 
     context.close();
   }

--- a/spring-fw-suheyon/src/main/java/com/fw/Main.java
+++ b/spring-fw-suheyon/src/main/java/com/fw/Main.java
@@ -1,7 +1,9 @@
 package com.fw;
 
 import com.fw.week5.HelloService;
+import com.fw.week6.AppConfig;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
 @Slf4j
@@ -9,7 +11,10 @@ public class Main {
 
   public static void main(String[] args) {
 
-    ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("week5.xml");
+    // xml
+    // ClassPathXmlApplicationContext context = new ClassPathXmlApplicationContext("week5.xml");
+    // AppConfig
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(AppConfig.class);
 
     HelloService helloService = context.getBean(HelloService.class);
     helloService.sayHello();

--- a/spring-fw-suheyon/src/main/java/com/fw/week5/GamjaServiceImpl.java
+++ b/spring-fw-suheyon/src/main/java/com/fw/week5/GamjaServiceImpl.java
@@ -2,8 +2,10 @@ package com.fw.week5;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 @Slf4j
+@Service
 public class GamjaServiceImpl implements MyService {
   @Value("${gamja.count}")
   private String gamjaCount;

--- a/spring-fw-suheyon/src/main/java/com/fw/week5/GamjaServiceImpl.java
+++ b/spring-fw-suheyon/src/main/java/com/fw/week5/GamjaServiceImpl.java
@@ -2,13 +2,19 @@ package com.fw.week5;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
+@Scope("prototype")
 public class GamjaServiceImpl implements MyService {
   @Value("${gamja.count}")
   private String gamjaCount;
+
+  public GamjaServiceImpl() {
+    log.info("GamjaServiceImpl instance created!: this={}", this);
+  }
 
   @Override
   public void hello() {

--- a/spring-fw-suheyon/src/main/java/com/fw/week5/HelloService.java
+++ b/spring-fw-suheyon/src/main/java/com/fw/week5/HelloService.java
@@ -4,8 +4,10 @@ import jakarta.annotation.Resource;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
 
 @Slf4j
+@Service
 public class HelloService {
 
   @Autowired

--- a/spring-fw-suheyon/src/main/java/com/fw/week5/MyServiceImpl.java
+++ b/spring-fw-suheyon/src/main/java/com/fw/week5/MyServiceImpl.java
@@ -1,8 +1,10 @@
 package com.fw.week5;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @Slf4j
+@Service
 public class MyServiceImpl implements MyService {
 
   @Override

--- a/spring-fw-suheyon/src/main/java/com/fw/week6/AppConfig.java
+++ b/spring-fw-suheyon/src/main/java/com/fw/week6/AppConfig.java
@@ -1,0 +1,14 @@
+package com.fw.week6;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+@Slf4j
+@Configuration
+@ComponentScan(basePackages = "com.fw")
+@PropertySource("classpath:gamja.properties")
+public class AppConfig {
+
+}

--- a/spring-fw-suheyon/src/main/resources/gamja.properties
+++ b/spring-fw-suheyon/src/main/resources/gamja.properties
@@ -1,1 +1,1 @@
-gamja.count=100
+gamja.count=10


### PR DESCRIPTION
Issue: https://github.com/juhwanHeo/study-spring/issues/61

1. 빈을 정의할 때, Stereotype Annotation을 사용하는 이유를 설명해봅시다.

클래스에 역할을 명시하기 위해, 컴포넌트 스캔을 통해 자동으로 스프링 빈으로 등록하기 위해 사용한다.

2. Stereotype Annotation 중 @service 를 사용하여 빈 정의를 합니다.
<img width="1452" height="614" alt="image" src="https://github.com/user-attachments/assets/853b16e5-d36b-4b74-a406-a818c851981e" />

3. GamjaServiceImpl 빈을 사용할 때마다 새로운 빈을 만들어 사용하도록 Scope를 지정해봅시다.
<img width="1446" height="569" alt="image" src="https://github.com/user-attachments/assets/5cd233ed-4927-4d21-ad14-3aaa1805d164" />
