### PR TITLE
Week6 / juwonlee

### DIFF
--- a/spring-fw-juwonlee/src/main/java/com/fw/Main.java
+++ b/spring-fw-juwonlee/src/main/java/com/fw/Main.java
@@ -1,5 +1,6 @@
 package com.fw;
 
+import com.fw.week5.GamjaServiceImpl;
 import com.fw.week5.HelloService;
 import com.fw.week6.AppConfig;
 import lombok.extern.slf4j.Slf4j;
@@ -16,5 +17,7 @@ public class Main {
         HelloService helloService = context.getBean(HelloService.class);
 
         helloService.sayHello();
+
+        for (int i = 0; i < 10; i++) context.getBean("gamjaServiceImpl");
     }
 }

--- a/spring-fw-juwonlee/src/main/java/com/fw/Main.java
+++ b/spring-fw-juwonlee/src/main/java/com/fw/Main.java
@@ -1,6 +1,5 @@
 package com.fw;
 
-import com.fw.week5.GamjaServiceImpl;
 import com.fw.week5.HelloService;
 import com.fw.week6.AppConfig;
 import lombok.extern.slf4j.Slf4j;

--- a/spring-fw-juwonlee/src/main/java/com/fw/Main.java
+++ b/spring-fw-juwonlee/src/main/java/com/fw/Main.java
@@ -1,9 +1,10 @@
 package com.fw;
 
 import com.fw.week5.HelloService;
+import com.fw.week6.AppConfig;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 @Slf4j
 public class Main {
@@ -11,11 +12,9 @@ public class Main {
     public static void main(String[] args) {
         log.info("Hello World");
 
-        ConfigurableApplicationContext context = new ClassPathXmlApplicationContext("week5.xml");
+        ApplicationContext context = new AnnotationConfigApplicationContext(AppConfig.class);
         HelloService helloService = context.getBean(HelloService.class);
 
         helloService.sayHello();
-
-        context.close();
     }
 }

--- a/spring-fw-juwonlee/src/main/java/com/fw/week5/GamjaServiceImpl.java
+++ b/spring-fw-juwonlee/src/main/java/com/fw/week5/GamjaServiceImpl.java
@@ -2,8 +2,10 @@ package com.fw.week5;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 @Slf4j
+@Service("gamjaServiceImpl")
 public class GamjaServiceImpl implements MyService {
 
     @Value("${gamja.count}")

--- a/spring-fw-juwonlee/src/main/java/com/fw/week5/GamjaServiceImpl.java
+++ b/spring-fw-juwonlee/src/main/java/com/fw/week5/GamjaServiceImpl.java
@@ -1,15 +1,23 @@
 package com.fw.week5;
 
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service("gamjaServiceImpl")
+@Scope("prototype")
 public class GamjaServiceImpl implements MyService {
 
     @Value("${gamja.count}")
     private int count;
+
+    @PostConstruct
+    public void init() {
+        log.info("GamjaServiceImpl init");
+    }
 
     @Override
     public void hello() {

--- a/spring-fw-juwonlee/src/main/java/com/fw/week5/HelloService.java
+++ b/spring-fw-juwonlee/src/main/java/com/fw/week5/HelloService.java
@@ -3,7 +3,9 @@ package com.fw.week5;
 import jakarta.annotation.Resource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
 
+@Service
 public class HelloService {
 
     @Autowired

--- a/spring-fw-juwonlee/src/main/java/com/fw/week5/MyServiceImpl.java
+++ b/spring-fw-juwonlee/src/main/java/com/fw/week5/MyServiceImpl.java
@@ -1,8 +1,10 @@
 package com.fw.week5;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @Slf4j
+@Service("myServiceImpl")
 public class MyServiceImpl implements MyService {
 
     @Override

--- a/spring-fw-juwonlee/src/main/java/com/fw/week6/AppConfig.java
+++ b/spring-fw-juwonlee/src/main/java/com/fw/week6/AppConfig.java
@@ -1,0 +1,18 @@
+package com.fw.week6;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+@Configuration
+@ComponentScan("com.fw")
+@PropertySource("classpath:gamja.properties")
+public class AppConfig {
+    
+    @Bean
+    public static PropertySourcesPlaceholderConfigurer propertySourcesPlaceholderConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
+    }
+}


### PR DESCRIPTION
#61

1. 빈을 정의할 때, Stereotype Annotation을 사용하는 이유를 설명해봅시다.
> Stereotype Annotation은 계층 구조를 명확하게 표현할 수 있어 직관적이므로 개발 생산성과 유지보수에 용이합니다.


2. Stereotype Annotation 중 @Service 를 사용하여 빈 정의를 합니다.
<img width="2119" height="447" alt="image" src="https://github.com/user-attachments/assets/1868aec4-da13-49f4-9abc-ae278aaac87b" />


3. GamjaServiceImpl 빈을 사용할 때마다 새로운 빈을 만들어 사용하도록 Scope를 지정해봅시다.
<img width="2123" height="886" alt="image" src="https://github.com/user-attachments/assets/0c5d5fb9-340b-4a33-8646-1de0288cab03" />
