### PR TITLE
Week6/inseo

### DIFF
--- a/spring-fw-inseo/src/main/java/com/fw/Main.java
+++ b/spring-fw-inseo/src/main/java/com/fw/Main.java
@@ -1,6 +1,7 @@
 package com.fw;
 
 import com.fw.week5.HelloService;
+import com.fw.week5.MyService;
 import com.fw.week6.AppConfig;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
@@ -12,6 +13,15 @@ public class Main {
 
         HelloService helloService = context.getBean(HelloService.class);
         helloService.sayHello();
+
+        System.out.println("----- GamjaServiceImpl prototype scope 확인 -----");
+
+        for (int i = 1; i <= 10; i++) {
+            System.out.println(i + "번째 GamjaServiceImpl 호출");
+            MyService gamjaService =
+                    context.getBean("gamjaServiceImpl", MyService.class);
+            gamjaService.hello();
+        }
 
         context.close();
     }

--- a/spring-fw-inseo/src/main/java/com/fw/Main.java
+++ b/spring-fw-inseo/src/main/java/com/fw/Main.java
@@ -1,24 +1,17 @@
 package com.fw;
 
-import com.fw.week2.Person;
-import com.fw.week3.Vegetable;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import com.fw.week5.HelloService;
+import com.fw.week6.AppConfig;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 
 public class Main {
     public static void main(String[] args) {
 
-        ClassPathXmlApplicationContext context =
-                new ClassPathXmlApplicationContext("week4.xml");
+        AnnotationConfigApplicationContext context =
+                new AnnotationConfigApplicationContext(AppConfig.class);
 
-        // 1. Person 먼저 호출
-        Person person = context.getBean("inseo", Person.class);
-        person.hello();
-
-        System.out.println("----- Bean Definition Inheritance -----");
-
-        Person inheritPerson = context.getBean("inheritPerson", Person.class);
-        inheritPerson.hello();
-
+        HelloService helloService = context.getBean(HelloService.class);
+        helloService.sayHello();
 
         context.close();
     }

--- a/spring-fw-inseo/src/main/java/com/fw/week5/GamjaServiceImpl.java
+++ b/spring-fw-inseo/src/main/java/com/fw/week5/GamjaServiceImpl.java
@@ -1,17 +1,22 @@
 package com.fw.week5;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
 @Service("gamjaServiceImpl")
+@Scope("prototype")
 public class GamjaServiceImpl implements MyService {
 
     @Value("${gamja.count}")
     private int count;
 
+    public GamjaServiceImpl() {
+        System.out.println("GamjaServiceImpl 새 빈 생성");
+    }
+
     @Override
     public void hello() {
-        System.out.println("GamjaServiceImpl Hello");
         System.out.println("GamjaServiceImpl gamja count: " + count);
     }
 }

--- a/spring-fw-inseo/src/main/java/com/fw/week5/GamjaServiceImpl.java
+++ b/spring-fw-inseo/src/main/java/com/fw/week5/GamjaServiceImpl.java
@@ -1,7 +1,9 @@
 package com.fw.week5;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
+@Service("gamjaServiceImpl")
 public class GamjaServiceImpl implements MyService {
 
     @Value("${gamja.count}")

--- a/spring-fw-inseo/src/main/java/com/fw/week5/HelloService.java
+++ b/spring-fw-inseo/src/main/java/com/fw/week5/HelloService.java
@@ -2,7 +2,9 @@ package com.fw.week5;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
 
+@Service
 public class HelloService {
 
     @Autowired

--- a/spring-fw-inseo/src/main/java/com/fw/week5/MyServiceImpl.java
+++ b/spring-fw-inseo/src/main/java/com/fw/week5/MyServiceImpl.java
@@ -1,5 +1,8 @@
 package com.fw.week5;
 
+import org.springframework.stereotype.Service;
+
+@Service("myServiceImpl")
 public class MyServiceImpl implements MyService {
 
     @Override

--- a/spring-fw-inseo/src/main/java/com/fw/week6/AppConfig.java
+++ b/spring-fw-inseo/src/main/java/com/fw/week6/AppConfig.java
@@ -1,0 +1,18 @@
+package com.fw.week6;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+@Configuration
+@ComponentScan("com.fw")
+@PropertySource("classpath:gamja.properties")
+public class AppConfig {
+
+    @Bean
+    public static PropertySourcesPlaceholderConfigurer propertyConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
+    }
+}


### PR DESCRIPTION
1. 빈을 정의할 때, Stereotype Annotation을 사용하는 이유를 설명해봅시다.
Stereotype Annotation은 클래스를 Spring Bean으로 등록하면서, 해당 클래스의 역할을 명확하게 표현하기 위해 사용합니다. 또한 Component Scan을 통해 XML 설정 없이 자동으로 Bean을 등록할 수 있게 해줍니다.

2. Stereotype Annotation 중 @Service 를 사용하여 빈 정의를 합니다.
<img width="887" height="674" alt="week6 2번 문제" src="https://github.com/user-attachments/assets/a4e17457-fba0-4fba-a32d-bebfbed63b5e" />

3. GamjaServiceImpl 빈을 사용할 때마다 새로운 빈을 만들어 사용하도록 Scope를 지정해봅시다.
해당 Scope로 설정한 이유를 PR에 적어주세요.
GamjaServiceImpl을 사용할 때마다 새로운 빈이 생성되는 것을 확인하기 위해 prototype scope로 설정했습니다.
singleton은 하나의 빈을 재사용하지만, prototype은 getBean()을 호출할 때마다 새로운 인스턴스를 생성합니다
<img width="926" height="1121" alt="week6 3번 문제" src="https://github.com/user-attachments/assets/96ca53b8-007f-44d9-b95e-b3224d572a58" />
