### PR TITLE
Week7 / juhwan

### DIFF
--- a/spring-fw-juhwan/src/main/java/com/fw/Main.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/Main.java
@@ -1,7 +1,7 @@
 package com.fw;
 
-import com.fw.week5.HelloService;
-import com.fw.week6.AppConfig;
+import com.fw.week7.AppConfig;
+import com.fw.week7.Transfer;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
@@ -12,10 +12,7 @@ public class Main {
   public static void main(String[] args) {
     ApplicationContext context =
         new AnnotationConfigApplicationContext(AppConfig.class);
-
-    HelloService helloService = context.getBean(HelloService.class);
-
-    helloService.sayHello();
-
+    Transfer transfer = context.getBean(Transfer.class);
+    transfer.transfer();
   }
 }

--- a/spring-fw-juhwan/src/main/java/com/fw/Main.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/Main.java
@@ -14,10 +14,8 @@ public class Main {
         new AnnotationConfigApplicationContext(AppConfig.class);
 
     HelloService helloService = context.getBean(HelloService.class);
+
     helloService.sayHello();
 
-    for (int i = 0; i < 10; i++) {
-      context.getBean("gamjaServiceImpl");
-    }
   }
 }

--- a/spring-fw-juhwan/src/main/java/com/fw/week5/HelloService.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/week5/HelloService.java
@@ -1,6 +1,7 @@
 package com.fw.week5;
 
 import jakarta.annotation.Resource;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -12,12 +13,17 @@ public class HelloService {
   @Qualifier("myServiceImpl")
   private MyService myService;
 
+//  private MyService gamjaService;
+
   @Resource
   @Qualifier("gamjaServiceImpl")
-  private MyService gamjaService;
+  private ObjectProvider<MyService> myServiceProvider;
 
   public void sayHello() {
     myService.hello();
-    gamjaService.hello();
+    MyService ifAvailable = myServiceProvider.getIfAvailable();
+    if (ifAvailable != null) {
+      ifAvailable.hello();
+    }
   }
 }

--- a/spring-fw-juhwan/src/main/java/com/fw/week7/AppConfig.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/week7/AppConfig.java
@@ -1,0 +1,27 @@
+package com.fw.week7;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+
+
+@Configuration
+@ComponentScan("com.fw")
+@PropertySource("classpath:gamja.properties")
+public class AppConfig {
+
+  @Value("${gamja.count}")
+  private int count;
+
+  @Bean
+  public Gamja gamja() {
+    return new Gamja(count);
+  }
+
+  @Bean
+  public Transfer transfer(Gamja gamja) {
+    return new Transfer(gamja);
+  }
+}

--- a/spring-fw-juhwan/src/main/java/com/fw/week7/Gamja.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/week7/Gamja.java
@@ -1,0 +1,20 @@
+package com.fw.week7;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Data
+@Slf4j
+public class Gamja implements TransferObject {
+
+  private final int count;
+
+  public Gamja(int count) {
+    this.count = count;
+  }
+
+  @Override
+  public int transferCount() {
+    return count;
+  }
+}

--- a/spring-fw-juhwan/src/main/java/com/fw/week7/Transfer.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/week7/Transfer.java
@@ -1,0 +1,20 @@
+package com.fw.week7;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class Transfer {
+
+  private final Gamja gamja;
+
+  public Transfer(Gamja gamja) {
+    this.gamja = gamja;
+  }
+
+  public void transfer() {
+    log.info("이동 시작");
+    int transferCount = gamja.transferCount();
+    log.info("이동 종료");
+    log.info("이동된 수: {}", transferCount);
+  }
+}

--- a/spring-fw-juhwan/src/main/java/com/fw/week7/TransferObject.java
+++ b/spring-fw-juhwan/src/main/java/com/fw/week7/TransferObject.java
@@ -1,0 +1,6 @@
+package com.fw.week7;
+
+public interface TransferObject {
+
+  int transferCount();
+}


### PR DESCRIPTION
### Issue: #71
### Task2
<img width="599" height="100" alt="image" src="https://github.com/user-attachments/assets/482cfcf7-216a-4706-b722-895f00342004" />
- com.fw.week7.AppConfig에 사용한 Annotation을 사용한 이유
  - `@Configuration` Annotation을 사용
  - 이유: streotype 빈 정의 annotation을 사용하지 않고, bean.xml 파일을 대체할 수 있는 설정 클래스 파일로 정의해 gamja, transfer 빈을 AppConfig 클래스에 정의함 