### PR TITLE
Week6/hyunjin

### DIFF
--- a/spring-fw-hyunjin/src/main/java/com/fw/Main.java
+++ b/spring-fw-hyunjin/src/main/java/com/fw/Main.java
@@ -15,5 +15,9 @@ public class Main {
 
         HelloService helloService = context.getBean(HelloService.class);
         helloService.sayHello();
+
+        for (int i = 0; i < 10; i++){
+            context.getBean("gamjaServiceImpl");
+        }
     }
 }

--- a/spring-fw-hyunjin/src/main/java/com/fw/Main.java
+++ b/spring-fw-hyunjin/src/main/java/com/fw/Main.java
@@ -1,17 +1,19 @@
 package com.fw;
 
 import com.fw.week5.HelloService;
+import com.fw.week6.AppConfig;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.ConfigurableApplicationContext;
-import org.springframework.context.support.ClassPathXmlApplicationContext;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+
+@Slf4j
 public class Main {
 
     public static void main(String[] args) {
-        ConfigurableApplicationContext context = new ClassPathXmlApplicationContext("week5.xml");
+        ApplicationContext context =
+                new AnnotationConfigApplicationContext(AppConfig.class);
 
         HelloService helloService = context.getBean(HelloService.class);
         helloService.sayHello();
-
-        context.close();
     }
 }

--- a/spring-fw-hyunjin/src/main/java/com/fw/week5/GamjaServiceImpl.java
+++ b/spring-fw-hyunjin/src/main/java/com/fw/week5/GamjaServiceImpl.java
@@ -2,8 +2,10 @@ package com.fw.week5;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 @Slf4j
+@Service("gamjaServiceImpl")
 public class GamjaServiceImpl implements MyService {
 
     @Value("${gamja.count}")

--- a/spring-fw-hyunjin/src/main/java/com/fw/week5/GamjaServiceImpl.java
+++ b/spring-fw-hyunjin/src/main/java/com/fw/week5/GamjaServiceImpl.java
@@ -1,15 +1,23 @@
 package com.fw.week5;
 
+import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Service;
 
 @Slf4j
+@Scope("prototype")
 @Service("gamjaServiceImpl")
 public class GamjaServiceImpl implements MyService {
 
     @Value("${gamja.count}")
     private int count;
+
+    @PostConstruct
+    public void init() {
+        log.info(">>> Gamja service init");
+    }
 
     @Override
     public void hello() {

--- a/spring-fw-hyunjin/src/main/java/com/fw/week5/HelloService.java
+++ b/spring-fw-hyunjin/src/main/java/com/fw/week5/HelloService.java
@@ -3,7 +3,9 @@ package com.fw.week5;
 import jakarta.annotation.Resource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
 
+@Service
 public class HelloService {
 
     @Autowired

--- a/spring-fw-hyunjin/src/main/java/com/fw/week5/MyServiceImpl.java
+++ b/spring-fw-hyunjin/src/main/java/com/fw/week5/MyServiceImpl.java
@@ -1,8 +1,10 @@
 package com.fw.week5;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
 
 @Slf4j
+@Service("myServiceImpl")
 public class MyServiceImpl implements MyService {
 
     @Override

--- a/spring-fw-hyunjin/src/main/java/com/fw/week6/AppConfig.java
+++ b/spring-fw-hyunjin/src/main/java/com/fw/week6/AppConfig.java
@@ -1,0 +1,4 @@
+package com.fw.week6;
+
+public class AppConfig {
+}

--- a/spring-fw-hyunjin/src/main/java/com/fw/week6/AppConfig.java
+++ b/spring-fw-hyunjin/src/main/java/com/fw/week6/AppConfig.java
@@ -1,4 +1,20 @@
 package com.fw.week6;
 
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.PropertySource;
+import org.springframework.context.support.PropertySourcesPlaceholderConfigurer;
+
+@Slf4j
+@Configuration
+@ComponentScan("com.fw")
+@PropertySource("classpath:gamja.properties")
 public class AppConfig {
+
+    @Bean
+    public static PropertySourcesPlaceholderConfigurer propertyConfigurer() {
+        return new PropertySourcesPlaceholderConfigurer();
+    }
 }


### PR DESCRIPTION
### Issue #61 

## Task

**1. 빈을 정의할 때, Stereotype Annotation을 사용하는 이유를 설명해봅시다.**
단순히 기술적으로 Bean 등록하는 것을 넘어, 해당 클래스가 프로젝트 내에서 어떤 역할을 맡고 있는가를 알 수 있다.
ex) @Controller : 웹 요청과 응답 처리 계층, @Service : 핵심 비즈니스 로직 구현 계층 , .  . .

**2. Stereotype Annotation 중 @Service 를 사용하여 빈 정의를 합니다.**
<img width="1386" height="556" alt="image" src="https://github.com/user-attachments/assets/f8375f3b-3cab-4d1e-b513-7bfa20cdafc0" />



**3. GamjaServiceImpl 빈을 사용할 때마다 새로운 빈을 만들어 사용하도록 Scope를 지정해봅시다.**
<img width="1423" height="659" alt="image" src="https://github.com/user-attachments/assets/67d2e92e-38ba-4073-90a1-11eb7072ebeb" />


- prototype scope를 선택한 이유 : singleton은 컨테이너 내에서 인스턴스를 하나만 생성해 공유하기 때문에, 빈 사용 시 새로운 빈을 만들어 사용하려면 prototype scope를 사용해야합니다. (prototype scope는 getBean() 호출할 때마다 새로운 독립적인 인스턴스를 생성함)
